### PR TITLE
[IMP] Melhora exibição dos campos monetários no boleto

### DIFF
--- a/pyboleto/html.py
+++ b/pyboleto/html.py
@@ -14,6 +14,7 @@ import string
 import sys
 import codecs
 import base64
+import locale
 
 from itertools import chain
 if sys.version_info < (3,):
@@ -244,9 +245,10 @@ class BoletoHTML(object):
                 fd.write(self.html)
 
     def _formataValorParaExibir(self, nfloat):
+        locale.setlocale(locale.LC_ALL, 'pt_BR.UTF-8')
         if nfloat:
-            txt = nfloat
-            txt = txt.replace('.', ',')
+            nfloat = float(nfloat)
+            txt = locale.currency(nfloat, grouping=True, symbol=None)
         else:
             txt = ""
         return txt

--- a/pyboleto/pdf.py
+++ b/pyboleto/pdf.py
@@ -9,6 +9,7 @@
     :license: BSD, see LICENSE for more details.
 
 """
+import locale
 import os
 
 from reportlab.graphics.barcode.common import I2of5
@@ -846,9 +847,10 @@ class BoletoPDF(object):
         self.pdf_canvas.line(x, y, x, y + width)
 
     def _formataValorParaExibir(self, nfloat):
+        locale.setlocale(locale.LC_ALL, 'pt_BR.UTF-8')
         if nfloat:
-            txt = nfloat
-            txt = txt.replace('.', ',')
+            nfloat = float(nfloat)
+            txt = locale.currency(nfloat, grouping=True, symbol=None)
         else:
             txt = ""
         return txt

--- a/tests/html/BoletoBB-expected.html
+++ b/tests/html/BoletoBB-expected.html
@@ -101,7 +101,7 @@
           <div class="rotulo">Endereço Cedente</div>  -  -  -  - 
         </td>
         <td width="100px" class="col-dir">
-          <div class="rotulo">Valor Documento</div> 2952,95
+          <div class="rotulo">Valor Documento</div> 2.952,95
         </td>
       </tr>
     </tbody>
@@ -184,7 +184,7 @@
           <div class="rotulo">Valor</div> 
         </td>
         <td>
-          <div class="rotulo">(=) Valor documento</div> 2952,95
+          <div class="rotulo">(=) Valor documento</div> 2.952,95
         </td>
       </tr>
       <tr>

--- a/tests/html/BoletoBradesco-expected.html
+++ b/tests/html/BoletoBradesco-expected.html
@@ -101,7 +101,7 @@
           <div class="rotulo">Endereço Cedente</div>  -  -  -  - 
         </td>
         <td width="100px" class="col-dir">
-          <div class="rotulo">Valor Documento</div> 8280,00
+          <div class="rotulo">Valor Documento</div> 8.280,00
         </td>
       </tr>
     </tbody>
@@ -184,7 +184,7 @@
           <div class="rotulo">Valor</div> 
         </td>
         <td>
-          <div class="rotulo">(=) Valor documento</div> 8280,00
+          <div class="rotulo">(=) Valor documento</div> 8.280,00
         </td>
       </tr>
       <tr>

--- a/tests/html/BoletoCaixa-expected.html
+++ b/tests/html/BoletoCaixa-expected.html
@@ -101,7 +101,7 @@
           <div class="rotulo">Endereço Cedente</div>  -  -  -  - 
         </td>
         <td width="100px" class="col-dir">
-          <div class="rotulo">Valor Documento</div> 2952,95
+          <div class="rotulo">Valor Documento</div> 2.952,95
         </td>
       </tr>
     </tbody>
@@ -184,7 +184,7 @@
           <div class="rotulo">Valor</div> 
         </td>
         <td>
-          <div class="rotulo">(=) Valor documento</div> 2952,95
+          <div class="rotulo">(=) Valor documento</div> 2.952,95
         </td>
       </tr>
       <tr>

--- a/tests/html/BoletoSantander-expected.html
+++ b/tests/html/BoletoSantander-expected.html
@@ -101,7 +101,7 @@
           <div class="rotulo">Endereço Cedente</div>  -  -  -  - 
         </td>
         <td width="100px" class="col-dir">
-          <div class="rotulo">Valor Documento</div> 2952,95
+          <div class="rotulo">Valor Documento</div> 2.952,95
         </td>
       </tr>
     </tbody>
@@ -184,7 +184,7 @@
           <div class="rotulo">Valor</div> 
         </td>
         <td>
-          <div class="rotulo">(=) Valor documento</div> 2952,95
+          <div class="rotulo">(=) Valor documento</div> 2.952,95
         </td>
       </tr>
       <tr>

--- a/tests/xml/BoletoBB-expected.xml
+++ b/tests/xml/BoletoBB-expected.xml
@@ -24,7 +24,7 @@
     <text font="0" height="8" left="658" top="547" width="82">(=) Valor documento</text>
     <text font="1" height="12" left="169" top="558" width="15">18</text>
     <text font="1" height="12" left="254" top="558" width="17">R$</text>
-    <text font="1" height="12" left="791" top="558" width="49">2952,95</text>
+    <text font="1" height="12" left="788" top="558" width="53">2.952,95</text>
     <text font="0" height="8" left="38" top="520" width="79">Data do documento</text>
     <text font="0" height="8" left="169" top="520" width="69">N. do documento</text>
     <text font="0" height="8" left="339" top="520" width="49">Esp&#233;cie doc</text>
@@ -76,6 +76,6 @@
     <text font="1" height="12" left="573" top="-172" width="38">87654</text>
     <text font="1" height="12" left="722" top="-172" width="68">08/03/2011</text>
     <text font="1" height="12" left="41" top="-145" width="48"> -  -  -  - </text>
-    <text font="1" height="12" left="722" top="-145" width="49">2952,95</text>
+    <text font="1" height="12" left="722" top="-145" width="53">2.952,95</text>
   </page>
 </pdf2xml>

--- a/tests/xml/BoletoBradesco-expected.xml
+++ b/tests/xml/BoletoBradesco-expected.xml
@@ -24,7 +24,7 @@
     <text font="0" height="8" left="658" top="547" width="82">(=) Valor documento</text>
     <text font="1" height="12" left="169" top="558" width="15">06</text>
     <text font="1" height="12" left="254" top="558" width="17">R$</text>
-    <text font="1" height="12" left="791" top="558" width="49">8280,00</text>
+    <text font="1" height="12" left="788" top="558" width="53">8.280,00</text>
     <text font="0" height="8" left="38" top="520" width="79">Data do documento</text>
     <text font="0" height="8" left="169" top="520" width="69">N. do documento</text>
     <text font="0" height="8" left="339" top="520" width="49">Esp&#233;cie doc</text>
@@ -76,6 +76,6 @@
     <text font="1" height="12" left="573" top="-172" width="53">2125525</text>
     <text font="1" height="12" left="722" top="-172" width="68">18/01/2011</text>
     <text font="1" height="12" left="41" top="-145" width="48"> -  -  -  - </text>
-    <text font="1" height="12" left="722" top="-145" width="49">8280,00</text>
+    <text font="1" height="12" left="722" top="-145" width="53">8.280,00</text>
   </page>
 </pdf2xml>

--- a/tests/xml/BoletoCaixa-expected.xml
+++ b/tests/xml/BoletoCaixa-expected.xml
@@ -24,7 +24,7 @@
     <text font="0" height="8" left="658" top="547" width="82">(=) Valor documento</text>
     <text font="1" height="12" left="169" top="558" width="19">SR</text>
     <text font="1" height="12" left="254" top="558" width="17">R$</text>
-    <text font="1" height="12" left="791" top="558" width="49">2952,95</text>
+    <text font="1" height="12" left="788" top="558" width="53">2.952,95</text>
     <text font="0" height="8" left="38" top="520" width="79">Data do documento</text>
     <text font="0" height="8" left="169" top="520" width="69">N. do documento</text>
     <text font="0" height="8" left="339" top="520" width="49">Esp&#233;cie doc</text>
@@ -76,6 +76,6 @@
     <text font="1" height="12" left="573" top="-172" width="68">270319510</text>
     <text font="1" height="12" left="722" top="-172" width="68">03/07/2012</text>
     <text font="1" height="12" left="41" top="-145" width="48"> -  -  -  - </text>
-    <text font="1" height="12" left="722" top="-145" width="49">2952,95</text>
+    <text font="1" height="12" left="722" top="-145" width="53">2.952,95</text>
   </page>
 </pdf2xml>

--- a/tests/xml/BoletoSantander-expected.xml
+++ b/tests/xml/BoletoSantander-expected.xml
@@ -24,7 +24,7 @@
     <text font="0" height="8" left="658" top="547" width="82">(=) Valor documento</text>
     <text font="1" height="12" left="169" top="558" width="23">102</text>
     <text font="1" height="12" left="254" top="558" width="17">R$</text>
-    <text font="1" height="12" left="791" top="558" width="49">2952,95</text>
+    <text font="1" height="12" left="788" top="558" width="53">2.952,95</text>
     <text font="0" height="8" left="38" top="520" width="79">Data do documento</text>
     <text font="0" height="8" left="169" top="520" width="69">N. do documento</text>
     <text font="0" height="8" left="339" top="520" width="49">Esp&#233;cie doc</text>
@@ -76,6 +76,6 @@
     <text font="1" height="12" left="573" top="-172" width="38">12345</text>
     <text font="1" height="12" left="722" top="-172" width="68">17/07/2012</text>
     <text font="1" height="12" left="41" top="-145" width="48"> -  -  -  - </text>
-    <text font="1" height="12" left="722" top="-145" width="49">2952,95</text>
+    <text font="1" height="12" left="722" top="-145" width="53">2.952,95</text>
   </page>
 </pdf2xml>

--- a/tests/xml/Triplo-BoletoBB-expected.xml
+++ b/tests/xml/Triplo-BoletoBB-expected.xml
@@ -24,7 +24,7 @@
     <text font="0" height="8" left="658" top="547" width="82">(=) Valor documento</text>
     <text font="1" height="12" left="169" top="558" width="15">18</text>
     <text font="1" height="12" left="254" top="558" width="17">R$</text>
-    <text font="1" height="12" left="791" top="558" width="49">2952,95</text>
+    <text font="1" height="12" left="788" top="558" width="53">2.952,95</text>
     <text font="0" height="8" left="38" top="520" width="79">Data do documento</text>
     <text font="0" height="8" left="169" top="520" width="69">N. do documento</text>
     <text font="0" height="8" left="339" top="520" width="49">Esp&#233;cie doc</text>
@@ -76,7 +76,7 @@
     <text font="1" height="12" left="573" top="-172" width="38">87654</text>
     <text font="1" height="12" left="722" top="-172" width="68">08/03/2011</text>
     <text font="1" height="12" left="41" top="-145" width="48"> -  -  -  - </text>
-    <text font="1" height="12" left="722" top="-145" width="49">2952,95</text>
+    <text font="1" height="12" left="722" top="-145" width="53">2.952,95</text>
   </page>
   <page height="892" left="0" number="2" position="absolute" top="0" width="1262">
     <text font="0" height="8" left="651" top="770" width="196">Autentica&#231;&#227;o Mec&#226;nica / Ficha de Compensa&#231;&#227;o</text>
@@ -99,7 +99,7 @@
     <text font="0" height="8" left="658" top="547" width="82">(=) Valor documento</text>
     <text font="1" height="12" left="169" top="558" width="15">18</text>
     <text font="1" height="12" left="254" top="558" width="17">R$</text>
-    <text font="1" height="12" left="791" top="558" width="49">2952,95</text>
+    <text font="1" height="12" left="788" top="558" width="53">2.952,95</text>
     <text font="0" height="8" left="38" top="520" width="79">Data do documento</text>
     <text font="0" height="8" left="169" top="520" width="69">N. do documento</text>
     <text font="0" height="8" left="339" top="520" width="49">Esp&#233;cie doc</text>
@@ -151,7 +151,7 @@
     <text font="1" height="12" left="573" top="-172" width="38">87655</text>
     <text font="1" height="12" left="722" top="-172" width="68">08/03/2011</text>
     <text font="1" height="12" left="41" top="-145" width="48"> -  -  -  - </text>
-    <text font="1" height="12" left="722" top="-145" width="49">2952,95</text>
+    <text font="1" height="12" left="722" top="-145" width="53">2.952,95</text>
   </page>
   <page height="892" left="0" number="3" position="absolute" top="0" width="1262">
     <text font="0" height="8" left="651" top="770" width="196">Autentica&#231;&#227;o Mec&#226;nica / Ficha de Compensa&#231;&#227;o</text>
@@ -174,7 +174,7 @@
     <text font="0" height="8" left="658" top="547" width="82">(=) Valor documento</text>
     <text font="1" height="12" left="169" top="558" width="15">18</text>
     <text font="1" height="12" left="254" top="558" width="17">R$</text>
-    <text font="1" height="12" left="791" top="558" width="49">2952,95</text>
+    <text font="1" height="12" left="788" top="558" width="53">2.952,95</text>
     <text font="0" height="8" left="38" top="520" width="79">Data do documento</text>
     <text font="0" height="8" left="169" top="520" width="69">N. do documento</text>
     <text font="0" height="8" left="339" top="520" width="49">Esp&#233;cie doc</text>
@@ -226,6 +226,6 @@
     <text font="1" height="12" left="573" top="-172" width="38">87656</text>
     <text font="1" height="12" left="722" top="-172" width="68">08/03/2011</text>
     <text font="1" height="12" left="41" top="-145" width="48"> -  -  -  - </text>
-    <text font="1" height="12" left="722" top="-145" width="49">2952,95</text>
+    <text font="1" height="12" left="722" top="-145" width="53">2.952,95</text>
   </page>
 </pdf2xml>

--- a/tests/xml/Triplo-BoletoBradesco-expected.xml
+++ b/tests/xml/Triplo-BoletoBradesco-expected.xml
@@ -24,7 +24,7 @@
     <text font="0" height="8" left="658" top="547" width="82">(=) Valor documento</text>
     <text font="1" height="12" left="169" top="558" width="15">06</text>
     <text font="1" height="12" left="254" top="558" width="17">R$</text>
-    <text font="1" height="12" left="791" top="558" width="49">8280,00</text>
+    <text font="1" height="12" left="788" top="558" width="53">8.280,00</text>
     <text font="0" height="8" left="38" top="520" width="79">Data do documento</text>
     <text font="0" height="8" left="169" top="520" width="69">N. do documento</text>
     <text font="0" height="8" left="339" top="520" width="49">Esp&#233;cie doc</text>
@@ -76,7 +76,7 @@
     <text font="1" height="12" left="573" top="-172" width="53">2125525</text>
     <text font="1" height="12" left="722" top="-172" width="68">18/01/2011</text>
     <text font="1" height="12" left="41" top="-145" width="48"> -  -  -  - </text>
-    <text font="1" height="12" left="722" top="-145" width="49">8280,00</text>
+    <text font="1" height="12" left="722" top="-145" width="53">8.280,00</text>
   </page>
   <page height="892" left="0" number="2" position="absolute" top="0" width="1262">
     <text font="0" height="8" left="651" top="770" width="196">Autentica&#231;&#227;o Mec&#226;nica / Ficha de Compensa&#231;&#227;o</text>
@@ -99,7 +99,7 @@
     <text font="0" height="8" left="658" top="547" width="82">(=) Valor documento</text>
     <text font="1" height="12" left="169" top="558" width="15">06</text>
     <text font="1" height="12" left="254" top="558" width="17">R$</text>
-    <text font="1" height="12" left="791" top="558" width="49">8280,00</text>
+    <text font="1" height="12" left="788" top="558" width="53">8.280,00</text>
     <text font="0" height="8" left="38" top="520" width="79">Data do documento</text>
     <text font="0" height="8" left="169" top="520" width="69">N. do documento</text>
     <text font="0" height="8" left="339" top="520" width="49">Esp&#233;cie doc</text>
@@ -151,7 +151,7 @@
     <text font="1" height="12" left="573" top="-172" width="53">2125526</text>
     <text font="1" height="12" left="722" top="-172" width="68">18/01/2011</text>
     <text font="1" height="12" left="41" top="-145" width="48"> -  -  -  - </text>
-    <text font="1" height="12" left="722" top="-145" width="49">8280,00</text>
+    <text font="1" height="12" left="722" top="-145" width="53">8.280,00</text>
   </page>
   <page height="892" left="0" number="3" position="absolute" top="0" width="1262">
     <text font="0" height="8" left="651" top="770" width="196">Autentica&#231;&#227;o Mec&#226;nica / Ficha de Compensa&#231;&#227;o</text>
@@ -174,7 +174,7 @@
     <text font="0" height="8" left="658" top="547" width="82">(=) Valor documento</text>
     <text font="1" height="12" left="169" top="558" width="15">06</text>
     <text font="1" height="12" left="254" top="558" width="17">R$</text>
-    <text font="1" height="12" left="791" top="558" width="49">8280,00</text>
+    <text font="1" height="12" left="788" top="558" width="53">8.280,00</text>
     <text font="0" height="8" left="38" top="520" width="79">Data do documento</text>
     <text font="0" height="8" left="169" top="520" width="69">N. do documento</text>
     <text font="0" height="8" left="339" top="520" width="49">Esp&#233;cie doc</text>
@@ -226,6 +226,6 @@
     <text font="1" height="12" left="573" top="-172" width="53">2125527</text>
     <text font="1" height="12" left="722" top="-172" width="68">18/01/2011</text>
     <text font="1" height="12" left="41" top="-145" width="48"> -  -  -  - </text>
-    <text font="1" height="12" left="722" top="-145" width="49">8280,00</text>
+    <text font="1" height="12" left="722" top="-145" width="53">8.280,00</text>
   </page>
 </pdf2xml>

--- a/tests/xml/Triplo-BoletoCaixa-expected.xml
+++ b/tests/xml/Triplo-BoletoCaixa-expected.xml
@@ -24,7 +24,7 @@
     <text font="0" height="8" left="658" top="547" width="82">(=) Valor documento</text>
     <text font="1" height="12" left="169" top="558" width="19">SR</text>
     <text font="1" height="12" left="254" top="558" width="17">R$</text>
-    <text font="1" height="12" left="791" top="558" width="49">2952,95</text>
+    <text font="1" height="12" left="788" top="558" width="53">2.952,95</text>
     <text font="0" height="8" left="38" top="520" width="79">Data do documento</text>
     <text font="0" height="8" left="169" top="520" width="69">N. do documento</text>
     <text font="0" height="8" left="339" top="520" width="49">Esp&#233;cie doc</text>
@@ -76,7 +76,7 @@
     <text font="1" height="12" left="573" top="-172" width="68">270319510</text>
     <text font="1" height="12" left="722" top="-172" width="68">03/07/2012</text>
     <text font="1" height="12" left="41" top="-145" width="48"> -  -  -  - </text>
-    <text font="1" height="12" left="722" top="-145" width="49">2952,95</text>
+    <text font="1" height="12" left="722" top="-145" width="53">2.952,95</text>
   </page>
   <page height="892" left="0" number="2" position="absolute" top="0" width="1262">
     <text font="0" height="8" left="651" top="770" width="196">Autentica&#231;&#227;o Mec&#226;nica / Ficha de Compensa&#231;&#227;o</text>
@@ -99,7 +99,7 @@
     <text font="0" height="8" left="658" top="547" width="82">(=) Valor documento</text>
     <text font="1" height="12" left="169" top="558" width="19">SR</text>
     <text font="1" height="12" left="254" top="558" width="17">R$</text>
-    <text font="1" height="12" left="791" top="558" width="49">2952,95</text>
+    <text font="1" height="12" left="788" top="558" width="53">2.952,95</text>
     <text font="0" height="8" left="38" top="520" width="79">Data do documento</text>
     <text font="0" height="8" left="169" top="520" width="69">N. do documento</text>
     <text font="0" height="8" left="339" top="520" width="49">Esp&#233;cie doc</text>
@@ -151,7 +151,7 @@
     <text font="1" height="12" left="573" top="-172" width="68">270319511</text>
     <text font="1" height="12" left="722" top="-172" width="68">03/07/2012</text>
     <text font="1" height="12" left="41" top="-145" width="48"> -  -  -  - </text>
-    <text font="1" height="12" left="722" top="-145" width="49">2952,95</text>
+    <text font="1" height="12" left="722" top="-145" width="53">2.952,95</text>
   </page>
   <page height="892" left="0" number="3" position="absolute" top="0" width="1262">
     <text font="0" height="8" left="651" top="770" width="196">Autentica&#231;&#227;o Mec&#226;nica / Ficha de Compensa&#231;&#227;o</text>
@@ -174,7 +174,7 @@
     <text font="0" height="8" left="658" top="547" width="82">(=) Valor documento</text>
     <text font="1" height="12" left="169" top="558" width="19">SR</text>
     <text font="1" height="12" left="254" top="558" width="17">R$</text>
-    <text font="1" height="12" left="791" top="558" width="49">2952,95</text>
+    <text font="1" height="12" left="788" top="558" width="53">2.952,95</text>
     <text font="0" height="8" left="38" top="520" width="79">Data do documento</text>
     <text font="0" height="8" left="169" top="520" width="69">N. do documento</text>
     <text font="0" height="8" left="339" top="520" width="49">Esp&#233;cie doc</text>
@@ -226,6 +226,6 @@
     <text font="1" height="12" left="573" top="-172" width="68">270319512</text>
     <text font="1" height="12" left="722" top="-172" width="68">03/07/2012</text>
     <text font="1" height="12" left="41" top="-145" width="48"> -  -  -  - </text>
-    <text font="1" height="12" left="722" top="-145" width="49">2952,95</text>
+    <text font="1" height="12" left="722" top="-145" width="53">2.952,95</text>
   </page>
 </pdf2xml>

--- a/tests/xml/Triplo-BoletoSantander-expected.xml
+++ b/tests/xml/Triplo-BoletoSantander-expected.xml
@@ -24,7 +24,7 @@
     <text font="0" height="8" left="658" top="547" width="82">(=) Valor documento</text>
     <text font="1" height="12" left="169" top="558" width="23">102</text>
     <text font="1" height="12" left="254" top="558" width="17">R$</text>
-    <text font="1" height="12" left="791" top="558" width="49">2952,95</text>
+    <text font="1" height="12" left="788" top="558" width="53">2.952,95</text>
     <text font="0" height="8" left="38" top="520" width="79">Data do documento</text>
     <text font="0" height="8" left="169" top="520" width="69">N. do documento</text>
     <text font="0" height="8" left="339" top="520" width="49">Esp&#233;cie doc</text>
@@ -76,7 +76,7 @@
     <text font="1" height="12" left="573" top="-172" width="38">12345</text>
     <text font="1" height="12" left="722" top="-172" width="68">17/07/2012</text>
     <text font="1" height="12" left="41" top="-145" width="48"> -  -  -  - </text>
-    <text font="1" height="12" left="722" top="-145" width="49">2952,95</text>
+    <text font="1" height="12" left="722" top="-145" width="53">2.952,95</text>
   </page>
   <page height="892" left="0" number="2" position="absolute" top="0" width="1262">
     <text font="0" height="8" left="651" top="770" width="196">Autentica&#231;&#227;o Mec&#226;nica / Ficha de Compensa&#231;&#227;o</text>
@@ -99,7 +99,7 @@
     <text font="0" height="8" left="658" top="547" width="82">(=) Valor documento</text>
     <text font="1" height="12" left="169" top="558" width="23">102</text>
     <text font="1" height="12" left="254" top="558" width="17">R$</text>
-    <text font="1" height="12" left="791" top="558" width="49">2952,95</text>
+    <text font="1" height="12" left="788" top="558" width="53">2.952,95</text>
     <text font="0" height="8" left="38" top="520" width="79">Data do documento</text>
     <text font="0" height="8" left="169" top="520" width="69">N. do documento</text>
     <text font="0" height="8" left="339" top="520" width="49">Esp&#233;cie doc</text>
@@ -151,7 +151,7 @@
     <text font="1" height="12" left="573" top="-172" width="38">12346</text>
     <text font="1" height="12" left="722" top="-172" width="68">17/07/2012</text>
     <text font="1" height="12" left="41" top="-145" width="48"> -  -  -  - </text>
-    <text font="1" height="12" left="722" top="-145" width="49">2952,95</text>
+    <text font="1" height="12" left="722" top="-145" width="53">2.952,95</text>
   </page>
   <page height="892" left="0" number="3" position="absolute" top="0" width="1262">
     <text font="0" height="8" left="651" top="770" width="196">Autentica&#231;&#227;o Mec&#226;nica / Ficha de Compensa&#231;&#227;o</text>
@@ -174,7 +174,7 @@
     <text font="0" height="8" left="658" top="547" width="82">(=) Valor documento</text>
     <text font="1" height="12" left="169" top="558" width="23">102</text>
     <text font="1" height="12" left="254" top="558" width="17">R$</text>
-    <text font="1" height="12" left="791" top="558" width="49">2952,95</text>
+    <text font="1" height="12" left="788" top="558" width="53">2.952,95</text>
     <text font="0" height="8" left="38" top="520" width="79">Data do documento</text>
     <text font="0" height="8" left="169" top="520" width="69">N. do documento</text>
     <text font="0" height="8" left="339" top="520" width="49">Esp&#233;cie doc</text>
@@ -226,6 +226,6 @@
     <text font="1" height="12" left="573" top="-172" width="38">12347</text>
     <text font="1" height="12" left="722" top="-172" width="68">17/07/2012</text>
     <text font="1" height="12" left="41" top="-145" width="48"> -  -  -  - </text>
-    <text font="1" height="12" left="722" top="-145" width="49">2952,95</text>
+    <text font="1" height="12" left="722" top="-145" width="53">2.952,95</text>
   </page>
 </pdf2xml>


### PR DESCRIPTION
**Melhora exibição dos campos monetários no boleto.**

_Antes:_
![image](https://user-images.githubusercontent.com/23198657/42330304-4176e306-8049-11e8-918a-de98fcf55e92.png)

_Depois:_
![image](https://user-images.githubusercontent.com/23198657/42330314-466d6c90-8049-11e8-97d8-4f53415d202b.png)


